### PR TITLE
Update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "http://github.com/node-js-libs/cli.git"
   },
   "dependencies": {
-    "glob": "^5.0.10",
+    "glob": "^7.0.5",
     "exit": "0.1.2"
   },
   "contributors": [


### PR DESCRIPTION
Currently installing `cli` gives a warning:

```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

This PR updates the `glob` dependency to the most recent version which uses an updated `minimatch` version as well.

This PR fixes #83.